### PR TITLE
Work around for changes to Drush 4 SQL API throwing mysqldump error

### DIFF
--- a/dgb.drush.inc
+++ b/dgb.drush.inc
@@ -184,7 +184,11 @@ function drush_dgb_build_dump_command($db_spec = NULL) {
       if ($file = drush_get_option('result-file')) {
         $exec .= ' --result-file '. $file;
       }
-      $extra = ' --single-transaction --opt -Q' . _drush_sql_get_credentials($db_spec);
+			// Remove '--database=' as it was causing mysqldump errors.
+			$sql_creds = _drush_sql_get_credentials($db_spec);
+			$sql_creds = str_replace('--database=', '', $sql_creds);
+
+			$extra = ' --single-transaction --opt -Q' . $sql_creds;
       if (isset($data_only)) {
         $extra .= ' --no-create-info';
       }


### PR DESCRIPTION
Hey Scor,

Here's a (temporary?) work around for the mysqldump error. It turns out that Drush 4's sql.drush.inc automatically creates flags for all of the sql credentials, including '--database=DATABASE'. This last one is what is throwing the mysqldump error. I'm not sure what the write way to work this change into Drush 4 is, so I wrote a quick work around so that dgb will continue to work.

Cheers,
Michelle
