### PR TITLE
Remove -- before message options to avoid drush Unknown Options error.

### DIFF
--- a/dgb.drush.inc
+++ b/dgb.drush.inc
@@ -41,7 +41,7 @@ function dgb_drush_command() {
     'callback' => 'drush_dgb_commit',
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION,
     'options' => array(
-      '--m' => 'An explicit commit message (useful for manual commits for example).',
+      'm' => 'An explicit commit message (useful for manual commits for example).',
     ) + $options,
   );
 
@@ -58,7 +58,7 @@ function dgb_drush_command() {
     'callback' => 'drush_dgb_backup',
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION,
     'options' => array(
-      '--m' => 'An explicit commit message (useful for manual commits for example).',
+      'm' => 'An explicit commit message (useful for manual commits for example).',
     ) + $options,
   );
 


### PR DESCRIPTION
Hey scor,

The double dashes (--) before the m option is causing drush to throw Unknown Option (i.e. "Unknown option: --m.  See `drush help dgb-commit` for available options. To suppress this error, add the    [error]
option --strict=0."). This is happening at least with drush 5.

Cheers,
Rocket
